### PR TITLE
Fix breaking through block protection plugins

### DIFF
--- a/src/main/java/cyanogenoid/portablechests/BlockListener.java
+++ b/src/main/java/cyanogenoid/portablechests/BlockListener.java
@@ -3,6 +3,7 @@ package cyanogenoid.portablechests;
 import org.bukkit.block.*;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
@@ -15,7 +16,7 @@ import java.util.Objects;
 
 public class BlockListener implements Listener {
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void on(BlockBreakEvent e) {
         if (!e.isDropItems()) return;
 
@@ -48,7 +49,7 @@ public class BlockListener implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void on(BlockPlaceEvent e) {
         Block block = e.getBlock();
         BlockState blockState = block.getState();

--- a/src/main/java/cyanogenoid/portablechests/InventoryListener.java
+++ b/src/main/java/cyanogenoid/portablechests/InventoryListener.java
@@ -7,20 +7,20 @@ import org.bukkit.inventory.ItemStack;
 
 public class InventoryListener implements Listener {
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void on(InventoryPickupItemEvent e) {
         if (!(PortableChests.isContainer(e.getInventory()) || !PortableChests.isPortableContainer(e.getItem().getItemStack()))) return;
         if (!PortableChests.canNestItemStack(e.getItem().getItemStack())) e.setCancelled(true);
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void on(InventoryMoveItemEvent e) {
         if (e.getDestination().getType().equals(InventoryType.SHULKER_BOX)) return;
         if (!(PortableChests.isContainer(e.getDestination()) || !PortableChests.isPortableContainer(e.getItem()))) return;
         if (!PortableChests.canNestItemStack(e.getItem())) e.setCancelled(true);
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void on(InventoryClickEvent e) {
         if (e.getInventory().getType().equals(InventoryType.SHULKER_BOX)) return;
         if (!PortableChests.isContainer(e.getInventory())) return;
@@ -29,7 +29,7 @@ public class InventoryListener implements Listener {
         if (this.isPlayerMovingItemStackToContainer(e) && !PortableChests.canNestItemStack(itemStack, e.getWhoClicked())) e.setCancelled(true);
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void on(InventoryDragEvent e) {
         if (e.getInventory().getType().equals(InventoryType.SHULKER_BOX)) return;
         if (!PortableChests.isContainer(e.getInventory())) return;


### PR DESCRIPTION
When breaking blocks protected by GriefPrevention (and probably other plugins), the barrel will still drop. This will prevent cancelled events from being acted upon, which will prevent this exploit.